### PR TITLE
Symbol for adapter type

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -14,7 +14,7 @@ Lita.configure do |config|
 
   # The adapter you want to connect with. Make sure you've added the
   # appropriate gem to the Gemfile.
-  config.robot.adapter = ENV.fetch("LITA_ADAPTER", "shell")
+  config.robot.adapter = ENV.fetch("LITA_ADAPTER", "shell").to_sym
 
   config.adapters.slack.token = ENV.fetch("SLACK_TOKEN", "")
 end


### PR DESCRIPTION
Looks like some plugins expect the adapter type to be a symbol, even though http://docs.lita.io/getting-started/configuration/ says it can be either.
